### PR TITLE
fix:作成日時の表記形式を変更しました

### DIFF
--- a/src/public/index.php
+++ b/src/public/index.php
@@ -12,9 +12,13 @@ $statement = $pdo->prepare($sql);
 $statement->execute();
 $pages = $statement->fetchAll(PDO::FETCH_ASSOC);
 
+$standard_key_array = array(); // $standard_key_arrayを初期化
+
 foreach ($pages as $key => $value) {
-    $standard_key_array[$key] = $value['created_at'];
+    $standard_key_array[$key] = strtotime($value['created_at']);
+    $pages[$key]['created_at'] = date('Y年m月d日 H時i分s秒', $standard_key_array[$key]); // 日本語表記に変換
 }
+
 array_multisort($standard_key_array, SORT_DESC, $pages);
 ?>
 


### PR DESCRIPTION
## 作業対象

[作業をした教材のURL]
[https://www.notion.so/66b8236574fe48dea96c7e597668b1b4?pvs=4](url)
[作成したページのURL(index.php)
(http://localhost:8080/index.php)

## 作業詳細

作成日時の表記を変更しました。
例）変更前 2022-09-01 14:47:08 → 変更後 2022年09月01日14時47分08秒

<img width="547" alt="スクリーンショット 2023-05-18 20 47 41" src="https://github.com/mikan19/PHP-memo/assets/128659635/b5774679-fbe8-4836-a34d-ed8a4ced38b5">
